### PR TITLE
Atomはcontentにも本文が入っていることがあるので取得できるように対応した

### DIFF
--- a/src/app/controller/rss_controller.rs
+++ b/src/app/controller/rss_controller.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, io::{self, ErrorKind}};
+use std::{
+    collections::HashMap,
+    io::{self, ErrorKind},
+};
 
 use crate::app::{
     config::Config, entity::Entity, file::File, history::History, parser::Parser, prompt::Prompt,
@@ -67,10 +70,8 @@ impl RssController {
                 );
                 return;
             }
-            Err(e   ) => {
-                eprintln!(
-                    "エラーが発生しました。\n{}", e
-                );
+            Err(e) => {
+                eprintln!("エラーが発生しました。\n{}", e);
                 return;
             }
         };
@@ -139,15 +140,6 @@ impl RssController {
     }
 
     async fn fetch_rss(url: String) -> Result<String, reqwest::Error> {
-        // let mut file = File::open("tests/fixtures/sample.xml").unwrap();
-        // let mut response = String::new();
-        // file.read_to_string(&mut response).unwrap();
-
-        // TODO: 後で引数とかで切り替えたい
-        // let url: &str = "https://game.watch.impress.co.jp/data/rss/1.0/gmw/feed.rdf";
-        // let url: &str = "https://b.hatena.ne.jp/entrylist/it.rss";
-        // let url: &str = "https://rss.itmedia.co.jp/rss/2.0/netlab.xml"; // 2.0
-
         let response = reqwest::get(&url).await?;
         let body = response.text().await?;
         Ok(body)

--- a/src/app/entity.rs
+++ b/src/app/entity.rs
@@ -63,6 +63,7 @@ pub struct Item {
     pub title: Option<String>,
     pub description: Option<String>,
     pub summary: Option<String>,
+    pub content: Option<String>,
     pub link: Link,
     #[serde(rename = "pubDate")]
     pub pub_date: Option<String>,
@@ -70,12 +71,11 @@ pub struct Item {
 
 #[derive(Debug, Deserialize)]
 pub struct Rdf {
-    _channel: RdfChannel,
+    #[serde(skip)]
+    #[allow(dead_code)]
+    channel: Option<String>,
     pub item: Vec<Item>,
 }
-
-#[derive(Debug, Deserialize)]
-struct RdfChannel {}
 
 #[derive(Debug, Deserialize)]
 pub struct Rss {

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -53,10 +53,11 @@ impl Parser {
                 let atom: Atom = quick_xml::de::from_str(&body).unwrap();
                 atom.entry.iter().for_each(|item| {
                     let mut entity = Entity::new(EntityType::Atom);
+                    let description = item.summary.as_ref().or_else(|| item.content.as_ref());
                     entity.set_fields(
                         item.title.clone().unwrap_or_else(|| "".to_string()),
                         item.link.clone(),
-                        self.clean_string(item.summary.as_ref()),
+                        self.clean_string(description),
                         item.pub_date.clone(),
                     );
                     buf.push(entity);
@@ -106,7 +107,7 @@ impl Parser {
             .replace("\n", "")
             .replace("\r", "")
             .replace("\t", "")
-            .replace(" ", "");
+            .replace("&nbsp;", " ");
         tmp
     }
 }
@@ -212,6 +213,43 @@ mod tests {
                     <title>Example title 2</title>
                     <link href="https://example2.com"/>
                     <summary>Example description 2</summary>
+                    <pubDate>2024-05-24T18:00:08+09:00</pubDate>
+                </entry>
+            </feed>
+        "#
+        .to_string();
+
+        let result = parser.parse(body).unwrap();
+        assert!(result.len() == 2);
+
+        assert_eq!(result.get(0).unwrap().title, "Example title 1");
+        assert_eq!(result.get(0).unwrap().link, "https://example1.com");
+        assert_eq!(result.get(0).unwrap().description, "Example description 1");
+
+        assert_eq!(result.get(1).unwrap().title, "Example title 2");
+        assert_eq!(result.get(1).unwrap().link, "https://example2.com");
+        assert_eq!(result.get(1).unwrap().description, "Example description 2");
+    }
+
+    #[test]
+    fn test_parse_atom_content_instead_of_summary() {
+        let parser = Parser::new();
+        let body = r#"
+            <?xml version="1.0" encoding="UTF-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+                <title>Example title</title>
+                <link href="https://example.com"/>
+                <updated>2024-05-24T18:00:08+09:00</updated>
+                <entry>
+                    <title>Example title 1</title>
+                    <link href="https://example1.com"/>
+                    <content>Example description 1</content>
+                    <pubDate>2024-05-24T18:00:08+09:00</pubDate>
+                </entry>
+                <entry>
+                    <title>Example title 2</title>
+                    <link href="https://example2.com"/>
+                    <content>Example description 2</content>
                     <pubDate>2024-05-24T18:00:08+09:00</pubDate>
                 </entry>
             </feed>


### PR DESCRIPTION
- Atomはcontentにも本文が入っているので表示させる対応
- 半角スペースを置換してしまうと英文が読めないので置換を廃止